### PR TITLE
(bugfix) Prevent friend array from becoming null if you delete all friends

### DIFF
--- a/public/src/components/app.jsx
+++ b/public/src/components/app.jsx
@@ -112,13 +112,21 @@ export default class App extends React.Component {
 
     var newFriend = true;
 
-    friends.forEach(function(friend) {
+    if (username === this.state.currentUser.username) {
+      alert('You can\'t request yourself as a friend');
+      newFriend = false;
+    }
+
+    friends.forEach(function(friend, i) {
       if (friend.username === username && friend.status === 'pending') {
         alert('You\'ve already requested this person');
         newFriend = false;
       } else if (friend.username === username && friend.status === 'accepted') {
         alert('You\'re already friends with this person');
         newFriend = false;
+      } else if (friend.username === username && friend.status === 'denied') {
+        //Take a previously denied user out of the friends array before adding them again
+        friends.splice(i, 1);
       }
     });
     if (newFriend) {

--- a/public/src/components/app.jsx
+++ b/public/src/components/app.jsx
@@ -113,8 +113,11 @@ export default class App extends React.Component {
     var newFriend = true;
 
     friends.forEach(function(friend) {
-      if (friend.username === username) {
-        alert('You\'ve already friended this person');
+      if (friend.username === username && friend.status === 'pending') {
+        alert('You\'ve already requested this person');
+        newFriend = false;
+      } else if (friend.username === username && friend.status === 'accepted') {
+        alert('You\'re already friends with this person');
         newFriend = false;
       }
     });
@@ -167,7 +170,7 @@ export default class App extends React.Component {
 
     friends.forEach(function(userFriend, i) {
       if (userFriend.username === friend) {
-        friends.splice(i, 1); //Check for bug when all friends are deleted
+        userFriend.status = 'denied'; //Check for bug when all friends are deleted
       }
     });
 

--- a/public/src/components/navbar.jsx
+++ b/public/src/components/navbar.jsx
@@ -51,15 +51,23 @@ const Navbar = ({addPhoto, currentUser, selectAlbum, addFriend, friends, selecte
             <li className="dropdown">
               <button className="dropdown-toggle" data-toggle="dropdown"><span className="glyphicon glyphicon-bell"></span></button>
               <div className="dropdown-menu">
-                <p>Friend Requests</p>
+                <strong><p>Incoming Friend Requests</p></strong>
                 {friends.map((friend) => {
-                  if (friend.status === 'pending') {
+                  if (friend.status === 'pending' && friend.sender !== currentUser.username) {
                     return (<div>{friend.username}<button onClick={() => {confirmFriend(friend.username)}}><span className="glyphicon glyphicon-ok"></span></button><button onClick={() => {denyFriend(friend.username)}}><span className="glyphicon glyphicon-remove"></span></button></div>);
                     }
                   }
                 )}
 
-                <p>Friends</p>
+                <strong><p>Sent Friend Requests</p></strong>
+                {friends.map((friend) => {
+                  if (friend.status === 'pending' && friend.sender === currentUser.username) {
+                    return (<div>{friend.username}<button onClick={() => {denyFriend(friend.username)}}>Cancel request</button></div>);
+                    }
+                  }
+                )}
+
+                <strong><p>Friends</p></strong>
                 {friends.map((friend) => {
                   if (friend.status === 'accepted') {
                     return (<div>{friend.username}<button onClick={() => {showAlbums(friend.username)}}>Show albums</button><button onClick={() => {denyFriend(friend.username)}}><span className="glyphicon glyphicon-remove"></span></button></div>);

--- a/public/src/components/navbar.jsx
+++ b/public/src/components/navbar.jsx
@@ -31,6 +31,7 @@ const Navbar = ({addPhoto, currentUser, selectAlbum, addFriend, friends, selecte
             <span className="icon-bar"></span>
           </button>
           <a className="navbar-brand" href="/"><img src="../images/Chobi.png" /></a>
+          <h5 className="navbar-brand">Welcome, {currentUser.username}!</h5>
         </div>
 
         <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -49,7 +50,7 @@ const Navbar = ({addPhoto, currentUser, selectAlbum, addFriend, friends, selecte
 
 
             <li className="dropdown">
-              <button className="dropdown-toggle" data-toggle="dropdown"><span className="glyphicon glyphicon-bell"></span></button>
+              <button className="dropdown-toggle" data-toggle="dropdown"><span className="glyphicon glyphicon-user"></span></button>
               <div className="dropdown-menu">
                 <strong><p>Incoming Friend Requests</p></strong>
                 {friends.map((friend) => {

--- a/server/lib/request-handler.js
+++ b/server/lib/request-handler.js
@@ -120,7 +120,7 @@ requestHandler.denyFriend = function(req, res) { //Check for bug when all friend
   User.findOne({username: receiver}).then(function(receiver) {
     receiver.friends.forEach(function(friend, i) {
       if (friend.username === initiator) {
-        receiver.friends.splice(i, 1);
+        friend.status = 'denied';
       }
     });
     User.findOneAndUpdate({username: receiver}, {friends: receiver.friends}, {new: true}).then(function(oldUser){


### PR DESCRIPTION
This PR also makes it so friend requests only appear with approve/deny buttons for the person who has been requested, not the person who sent the request. Lines 62-68 of Navbar.jsx render friend requests that have been sent by the current user, but only provide a button for canceling the friend request in that case.

Later changes prevent a user from friending themselves and prevent multiple entries showing for friends who were previously denied and later approved.